### PR TITLE
Infra 1861/build support

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,76 @@
+#!groovy
+pipeline {
+    agent {
+        docker {
+            // Our custom docker image
+            image "build-zulu-openjdk:11"
+            label "standard"
+            registryUrl 'https://engineering-docker.software.r3.com/'
+            registryCredentialsId 'artifactory-credentials'
+            // Used to mount storage from the host as a volume to persist the cache between builds
+            args '-v /tmp:/host_tmp'
+            alwaysPull true
+        }
+    }
+    environment {
+        ARTIFACTORY_CREDENTIALS = credentials('artifactory-credentials')
+        ARTIFACTORY_BUILD_NAME = "Web3j artifact"
+        ARTIFACTORY_SERVER = "software.r3.com"
+        ARTIFACTORY_SERVER_ID = 'R3-Artifactory'
+        GRADLE_USER_HOME = "/host_tmp/gradle"
+        CORDA_ARTIFACTORY_PASSWORD = "${env.ARTIFACTORY_CREDENTIALS_PSW}"
+        CORDA_ARTIFACTORY_USERNAME = "${env.ARTIFACTORY_CREDENTIALS_USR}"
+        CORDA_ARTIFACTORY_REPOKEY =  "${isReleaseTag() ? 'corda-dependencies' : 'corda-dependencies-dev'}"
+    }
+    options {
+        ansiColor('xterm')
+        buildDiscarder logRotator(daysToKeepStr: '14')
+        disableConcurrentBuilds()
+        timestamps()
+        timeout(activity: true, time: 10)
+    }
+    stages {
+        stage('Build') {
+            steps {
+                sh './gradlew assemble'
+            }
+        }
+        stage('Publish') {
+            steps {
+                echo "Creating Artifactory server ${env.ARTIFACTORY_SERVER_ID}"
+                rtServer(
+                        id: "${env.ARTIFACTORY_SERVER_ID}",
+                        url: "https://${env.ARTIFACTORY_SERVER}/artifactory",
+                        credentialsId: 'artifactory-credentials'
+                )
+                rtBuildInfo(
+                        captureEnv: true,
+                        buildName: env.ARTIFACTORY_BUILD_NAME
+                )
+               rtGradleDeployer(
+                        id: 'deployer',
+                        serverId: 'R3-Artifactory',
+                        repo: '${CORDA_ARTIFACTORY_REPOKEY}'
+               )
+               rtGradleRun(
+                        usesPlugin: true,
+                        useWrapper: true,
+                        switches: '-s --info -x signMavenPublication',
+                        tasks: 'artifactoryPublish',
+                        deployerId: 'deployer',
+                        buildName: env.ARTIFACTORY_BUILD_NAME
+               )
+                echo 'Publishing build info to Artifactory server'
+                rtPublishBuildInfo(
+                        serverId: env.ARTIFACTORY_SERVER_ID,
+                        buildName: env.ARTIFACTORY_BUILD_NAME
+                )
+            }
+        }
+    }
+}
+
+
+def isReleaseTag() {
+    return (env.TAG_NAME =~ /^release-.*$/)
+}

--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ description 'web3j base project'
     download {
         src "https://raw.githubusercontent.com/web3j/build-tools/master/gradle/$buildScript/build.gradle"
         dest "$rootDir/gradle/$buildScript/build.gradle"
-        overwrite true
+        overwrite false
         quiet true
         onlyIfModified true
     }

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ plugins {
     id "de.marcphilipp.nexus-publish" version "0.4.0"
     id "de.undercouch.download" version "4.0.0"
     id "com.jfrog.bintray" version "1.8.4"
+    id "com.jfrog.artifactory" version "4.7.5"
 }
 
 ext {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 group=org.web3j
 version=4.9.0-CORDA4
+artifactory_contextUrl=https://software.r3.com/artifactory

--- a/gradle/publish/build.gradle
+++ b/gradle/publish/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
 apply plugin: "de.marcphilipp.nexus-publish"
+apply plugin: 'com.jfrog.artifactory'
 
 task javadocsJar(type: Jar) {
     archiveClassifier = 'javadoc'
@@ -87,5 +88,20 @@ signing {
     def signingKey = new File("$rootDir/web3j.asc")
     if (signingKey.exists()) {
         useInMemoryPgpKeys(signingKey.getText('UTF-8'), System.getenv('GPG_PASSPHRASE'))
+    }
+}
+
+artifactory {
+    publish {
+        contextUrl = artifactory_contextUrl
+        repository {
+            repoKey = System.getenv('CORDA_ARTIFACTORY_REPOKEY') ?: System.getProperty('corda.artifactory.repokey', 'corda-dependencies')
+            username = System.getenv('CORDA_ARTIFACTORY_USERNAME') ?: System.getProperty('corda.artifactory.username')
+            password = System.getenv('CORDA_ARTIFACTORY_PASSWORD') ?: System.getProperty('corda.artifactory.password')
+        }
+
+        defaults {
+            publications("maven")
+        }
     }
 }

--- a/gradle/publish/build.gradle
+++ b/gradle/publish/build.gradle
@@ -90,7 +90,6 @@ signing {
         useInMemoryPgpKeys(signingKey.getText('UTF-8'), System.getenv('GPG_PASSPHRASE'))
     }
 }
-
 artifactory {
     publish {
         contextUrl = artifactory_contextUrl


### PR DESCRIPTION
### What does this PR do?
Adds build support for publishing to artifactory in the corda-dependencies repo

### Why is it needed?
as requested

### Tested here
[Jenkins run](https://ci02.dev.r3.com/job/Maintained-Library's/job/web3j-corda-fork/job/INFRA-1861%2FBuild-support/3/)

